### PR TITLE
docs: fix typo in TLPMX.py function description

### DIFF
--- a/Python/Thorlabs PMxxx Power Meters/TLPMX_dll/TLPMX.py
+++ b/Python/Thorlabs PMxxx Power Meters/TLPMX_dll/TLPMX.py
@@ -2352,7 +2352,7 @@ class TLPMX:
 			
 			Return values:
 			  TLPM_AUTORANGE_POWER_OFF (0): power auto range disabled
-			  TLPM_AUTORANGE_POWER_ON  (0): power auto range enabled
+			  TLPM_AUTORANGE_POWER_ON  (1): power auto range enabled
 			
 			channel(c_uint16) : Number of the sensor channel. 
 			


### PR DESCRIPTION
This PR fixes the documentation typo in the TLPMX.py for the getPowerAutorange-function. 

The current docstring of the function states that both TLPM_AUTORANGE_POWER_OFF and TLPM_AUTORANGE_POWER_ON have the same value 0. According to the constants defined inside the file TLPM_AUTORANGE_POWER_ON should be 1 (not 0). 

Changes:
- Changed the docstring to reflect the correct value for TLPM_AUTORANGE_POWER_ON
 